### PR TITLE
Fix regression introduced when switching to globalThis.crypto.subtle

### DIFF
--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -31,7 +31,7 @@ export class AccessTokenAuthenticator {
         nowUnixSeconds?: number;
     }): Promise<AccessTokenClaims> {
         await this.updateConfigData();
-        return authenticateAccessToken({
+        return await authenticateAccessToken({
             jwks: this.jwks!,
             accessToken,
             nowUnixSeconds: nowUnixSeconds ?? Date.now() / 1000,
@@ -59,7 +59,7 @@ export class AccessTokenAuthenticator {
     }
 }
 
-function authenticateAccessToken({
+async function authenticateAccessToken({
     jwks,
     accessToken,
     nowUnixSeconds,
@@ -67,7 +67,7 @@ function authenticateAccessToken({
     jwks: Record<string, CryptoKey>;
     accessToken: string;
     nowUnixSeconds: number;
-}): AccessTokenClaims {
+}): Promise<AccessTokenClaims> {
     const parts = accessToken.split(".");
     if (parts.length !== 3) {
         throw new InvalidAccessTokenError();
@@ -83,7 +83,7 @@ function authenticateAccessToken({
     const publicKey = jwks[parsedHeader.kid];
 
     const signature = Buffer.from(rawSignature.replace(/-/g, "+").replace(/_/g, "/"), "base64");
-    const valid = globalThis.crypto.subtle.verify(
+    const valid = await globalThis.crypto.subtle.verify(
         {
             name: "ECDSA",
             hash: "SHA-256",

--- a/tests/authenticate.test.ts
+++ b/tests/authenticate.test.ts
@@ -53,35 +53,35 @@ const ACCESS_TOKEN_TEST_CASES = [
     },
     {
         name: "empty access token",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken: "",
         nowUnixSeconds: 1741195318,
         claims: null,
     },
     {
         name: "invalid base64 in header",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken: "e30.e30K.e30K",
         nowUnixSeconds: 1741195318,
         claims: null,
     },
     {
         name: "invalid base64 in claims",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken: "e30K.e30.e30K",
         nowUnixSeconds: 1741195318,
         claims: null,
     },
     {
         name: "invalid base64 in access signature",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken: "e30K.e30K.e30",
         nowUnixSeconds: 1741195318,
         claims: null,
     },
     {
         name: "no signature",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken:
             "eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2MzODR1Y2Exc2J1czR4cGtpN2oya2dhcXQiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJzdWIiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJhdWQiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJleHAiOjE3NDExOTU0NjgsIm5iZiI6MTc0MTE5NTE2OCwiaWF0IjoxNzQxMTk1MTY4LCJvcmdhbml6YXRpb24iOnsiaWQiOiJvcmdfNzkwOG16MnVsOXVzZGh5MGdkZDN0aWVhbiIsImRpc3BsYXlOYW1lIjoicHJvamVjdF81NHZ3ZjBjbGhoMGNhcWUyMGV1anhncGVxIEJhY2tpbmcgT3JnYW5pemF0aW9uIn0sInVzZXIiOnsiaWQiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJlbWFpbCI6InJvb3RAYXBwLnRlc3NlcmFsLmV4YW1wbGUuY29tIn0sInNlc3Npb24iOnsiaWQiOiJzZXNzaW9uXzAzZGkwbmtqbG1yNmh3cWQ0ejA4OTlvMnIifX0.",
         nowUnixSeconds: 1741195318,
@@ -89,15 +89,15 @@ const ACCESS_TOKEN_TEST_CASES = [
     },
     {
         name: "bad signature correct length",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken:
-            "eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2MzODR1Y2Exc2J1czR4cGtpN2oya2dhcXQiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJzdWIiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJhdWQiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJleHAiOjE3NDExOTU0NjgsIm5iZiI6MTc0MTE5NTE2OCwiaWF0IjoxNzQxMTk1MTY4LCJvcmdhbml6YXRpb24iOnsiaWQiOiJvcmdfNzkwOG16MnVsOXVzZGh5MGdkZDN0aWVhbiIsImRpc3BsYXlOYW1lIjoicHJvamVjdF81NHZ3ZjBjbGhoMGNhcWUyMGV1anhncGVxIEJhY2tpbmcgT3JnYW5pemF0aW9uIn0sInVzZXIiOnsiaWQiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJlbWFpbCI6InJvb3RAYXBwLnRlc3NlcmFsLmV4YW1wbGUuY29tIn0sInNlc3Npb24iOnsiaWQiOiJzZXNzaW9uXzAzZGkwbmtqbG1yNmh3cWQ0ejA4OTlvMnIifX0.utyHAIubtDLJAY9b3Ec_rMBOX9ejOA21sh2fpVHm34S3ywBpiM7Pe0SvsDWhZQh_GG7Il1-H3Eju7dBIDgvXXX",
+            "eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2MzODR1Y2Exc2J1czR4cGtpN2oya2dhcXQiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJzdWIiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJhdWQiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJleHAiOjE3NDExOTU0NjgsIm5iZiI6MTc0MTE5NTE2OCwiaWF0IjoxNzQxMTk1MTY4LCJvcmdhbml6YXRpb24iOnsiaWQiOiJvcmdfNzkwOG16MnVsOXVzZGh5MGdkZDN0aWVhbiIsImRpc3BsYXlOYW1lIjoicHJvamVjdF81NHZ3ZjBjbGhoMGNhcWUyMGV1anhncGVxIEJhY2tpbmcgT3JnYW5pemF0aW9uIn0sInVzZXIiOnsiaWQiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJlbWFpbCI6InJvb3RAYXBwLnRlc3NlcmFsLmV4YW1wbGUuY29tIn0sInNlc3Npb24iOnsiaWQiOiJzZXNzaW9uXzAzZGkwbmtqbG1yNmh3cWQ0ejA4OTlvMnIifX0.utyHAIubtDLJAY9b3Ec_rMBOX9ejOA21sh2fpVHm34S3ywBpiM7Pe0SvsDWhZQh_GG7Il1-H3Eju7dBIDgvAAA",
         nowUnixSeconds: 1741195318,
         claims: null,
     },
     {
         name: "bad signature too short",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken:
             "eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2MzODR1Y2Exc2J1czR4cGtpN2oya2dhcXQiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJzdWIiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJhdWQiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJleHAiOjE3NDExOTU0NjgsIm5iZiI6MTc0MTE5NTE2OCwiaWF0IjoxNzQxMTk1MTY4LCJvcmdhbml6YXRpb24iOnsiaWQiOiJvcmdfNzkwOG16MnVsOXVzZGh5MGdkZDN0aWVhbiIsImRpc3BsYXlOYW1lIjoicHJvamVjdF81NHZ3ZjBjbGhoMGNhcWUyMGV1anhncGVxIEJhY2tpbmcgT3JnYW5pemF0aW9uIn0sInVzZXIiOnsiaWQiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJlbWFpbCI6InJvb3RAYXBwLnRlc3NlcmFsLmV4YW1wbGUuY29tIn0sInNlc3Npb24iOnsiaWQiOiJzZXNzaW9uXzAzZGkwbmtqbG1yNmh3cWQ0ejA4OTlvMnIifX0.utyHAIubtDLJAY9b3Ec_rMBOX9ejOA21sh2fpVHm34S3ywBpiM7Pe0SvsDWhZQh_GG7Il1-H3Eju7dBIDgv",
         nowUnixSeconds: 1741195318,
@@ -105,7 +105,7 @@ const ACCESS_TOKEN_TEST_CASES = [
     },
     {
         name: "bad signature too long",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken:
             "eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2MzODR1Y2Exc2J1czR4cGtpN2oya2dhcXQiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJzdWIiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJhdWQiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJleHAiOjE3NDExOTU0NjgsIm5iZiI6MTc0MTE5NTE2OCwiaWF0IjoxNzQxMTk1MTY4LCJvcmdhbml6YXRpb24iOnsiaWQiOiJvcmdfNzkwOG16MnVsOXVzZGh5MGdkZDN0aWVhbiIsImRpc3BsYXlOYW1lIjoicHJvamVjdF81NHZ3ZjBjbGhoMGNhcWUyMGV1anhncGVxIEJhY2tpbmcgT3JnYW5pemF0aW9uIn0sInVzZXIiOnsiaWQiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJlbWFpbCI6InJvb3RAYXBwLnRlc3NlcmFsLmV4YW1wbGUuY29tIn0sInNlc3Npb24iOnsiaWQiOiJzZXNzaW9uXzAzZGkwbmtqbG1yNmh3cWQ0ejA4OTlvMnIifX0.utyHAIubtDLJAY9b3Ec_rMBOX9ejOA21sh2fpVHm34S3ywBpiM7Pe0SvsDWhZQh_GG7Il1-H3Eju7dBIDgvEEAXXX",
         nowUnixSeconds: 1741195318,
@@ -113,7 +113,7 @@ const ACCESS_TOKEN_TEST_CASES = [
     },
     {
         name: "bad signature invalid base64",
-        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"XXX","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
+        jwks: '{"projectId":"project_54vwf0clhh0caqe20eujxgpeq","vaultDomain":"auth.console.tesseral.example.com","keys":[{"crv":"P-256","kid":"session_signing_key_c384uca1sbus4xpki7j2kgaqt","kty":"EC","x":"qCByog0iFwVfDF-fkoPhKNW8JjNLGQJMk_atUGGbvoM","y":"vFZaL73AXgLcPxRS_yc9fsJTTiy-f-OVRD2IexKN17g"}]}',
         accessToken:
             "eyJraWQiOiJzZXNzaW9uX3NpZ25pbmdfa2V5X2MzODR1Y2Exc2J1czR4cGtpN2oya2dhcXQiLCJhbGciOiJFUzI1NiJ9.eyJpc3MiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJzdWIiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJhdWQiOiJodHRwczovL3Byb2plY3QtNTR2d2YwY2xoaDBjYXFlMjBldWp4Z3BlcS50ZXNzZXJhbC5hcHAiLCJleHAiOjE3NDExOTU0NjgsIm5iZiI6MTc0MTE5NTE2OCwiaWF0IjoxNzQxMTk1MTY4LCJvcmdhbml6YXRpb24iOnsiaWQiOiJvcmdfNzkwOG16MnVsOXVzZGh5MGdkZDN0aWVhbiIsImRpc3BsYXlOYW1lIjoicHJvamVjdF81NHZ3ZjBjbGhoMGNhcWUyMGV1anhncGVxIEJhY2tpbmcgT3JnYW5pemF0aW9uIn0sInVzZXIiOnsiaWQiOiJ1c2VyXzk3dXJxb2lwNXE3a2VmODd3cG90dnp6eHoiLCJlbWFpbCI6InJvb3RAYXBwLnRlc3NlcmFsLmV4YW1wbGUuY29tIn0sInNlc3Npb24iOnsiaWQiOiJzZXNzaW9uXzAzZGkwbmtqbG1yNmh3cWQ0ejA4OTlvMnIifX0.utyHAIubtDLJAY9b3Ec_rMBOX9ejOA21sh2fpVHm34S3ywBpiM7Pe0SvsDWhZQh_GG7Il1-H3Eju7dBIDgvEE=",
         nowUnixSeconds: 1741195318,
@@ -128,20 +128,20 @@ describe("authenticate", () => {
 
             if (testCase.claims) {
                 expect(
-                    __exportedForTests.authenticateAccessToken({
+                    await __exportedForTests.authenticateAccessToken({
                         jwks,
                         accessToken: testCase.accessToken,
                         nowUnixSeconds: testCase.nowUnixSeconds,
                     }),
                 ).toEqual(testCase.claims);
             } else {
-                expect(() =>
-                    __exportedForTests.authenticateAccessToken({
+                await expect(async () =>
+                    await __exportedForTests.authenticateAccessToken({
                         jwks,
                         accessToken: testCase.accessToken,
                         nowUnixSeconds: testCase.nowUnixSeconds,
                     }),
-                ).toThrow();
+                ).rejects.toThrow();
             }
         });
     }


### PR DESCRIPTION
This PR fixes a regression introduced when we switched to globalThis.crypto.subtle. It also updates test cases to ensure they exercise the branches we intended to test.