### PR TITLE
Export InvalidAccessTokenError

### DIFF
--- a/src/authenticate.ts
+++ b/src/authenticate.ts
@@ -135,7 +135,7 @@ async function parseConfig(configData: any): Promise<Config> {
     return { projectId: configData.projectId, jwks };
 }
 
-class InvalidAccessTokenError extends Error {
+export class InvalidAccessTokenError extends Error {
     constructor() {
         super("Invalid access token");
         Object.setPrototypeOf(this, InvalidAccessTokenError.prototype);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,4 @@ export * as Tesseral from "./api";
 export { TesseralClient } from "./Client";
 export { TesseralEnvironment } from "./environments";
 export { TesseralError, TesseralTimeoutError } from "./errors";
-export { AccessTokenAuthenticator } from "./authenticate";
+export { AccessTokenAuthenticator, InvalidAccessTokenError } from "./authenticate";


### PR DESCRIPTION
In order for our middlewares to check against the `InvalidAccessTokenError`, we need to export it from our node SDK.

This PR adds an additional export for this error.